### PR TITLE
feat: Add test tooling

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,10 @@
 module.exports = {
     root: true,
-    env: { browser: true, es2020: true },
+    env: {
+        browser: true,
+        es2020: true,
+        "vitest-globals/env": true
+    },
     extends: [
         "eslint:recommended",
         "plugin:react/recommended",
@@ -18,11 +22,11 @@ module.exports = {
         react: { version: "18.2" },
         "import/resolver": {
             "node": {
-              "extensions": [".js", ".jsx", ".ts", ".tsx"]
+              "extensions": [".js", ".jsx", ".ts", ".tsx", ".d.ts"]
             }
           }
     },
-    plugins: ["react-refresh"],
+    plugins: ["react-refresh", "vitest-globals"],
     rules: {
         "react/jsx-no-target-blank": "off",
         'react/jsx-filename-extension': [2, { 'extensions': ['.js', '.jsx', '.ts', '.tsx'] }],
@@ -55,8 +59,9 @@ module.exports = {
               "ts": "never",
               "tsx": "never"
             }
-          ]
-    },
+          ],
+          "react/react-in-jsx-scope": "off",
+        },
     overrides: [
         {
             "files": ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -11,7 +11,13 @@ const removeIgnoredFiles = async (files) => {
 
 export default {
     '**/*.{ts,tsx,js,jsx}': async (files) => {
-        const filesToLint = await removeIgnoredFiles(files)
-        return [`eslint --max-warnings=0 ${filesToLint}`]
+        try {
+            const filesToLint = await removeIgnoredFiles(files)
+            return [`eslint --max-warnings=0 ${filesToLint}`]
+        } catch (error) {
+            /* eslint-disable no-console */
+            console.error('Linting failed:', error);
+            return Promise.reject(error);
+        }
     },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
                 "@storybook/react": "^8.0.10",
                 "@storybook/react-vite": "^8.0.10",
                 "@storybook/test": "^8.0.10",
+                "@testing-library/jest-dom": "^6.6.2",
+                "@testing-library/react": "^16.0.1",
                 "@types/css-modules": "^1.0.5",
                 "@types/react": "^18.3.11",
                 "@types/react-dom": "^18.3.1",
@@ -33,7 +35,9 @@
                 "eslint-plugin-react-hooks": "^4.6.2",
                 "eslint-plugin-react-refresh": "^0.4.6",
                 "eslint-plugin-storybook": "^0.8.0",
+                "eslint-plugin-vitest-globals": "^1.5.0",
                 "husky": "^8.0.0",
+                "jsdom": "^25.0.1",
                 "lint-staged": "^15.2.2",
                 "maplibre-gl": "^4.3.2",
                 "prettier": "^3.2.5",
@@ -42,6 +46,7 @@
                 "typescript": "^5.6.3",
                 "vite": "^5.2.0",
                 "vite-plugin-dts": "^4.2.4",
+                "vitest": "^2.1.3",
                 "watch": "^1.0.2"
             },
             "peerDependencies": {
@@ -5155,6 +5160,106 @@
                 "url": "https://opencollective.com/storybook"
             }
         },
+        "node_modules/@storybook/test/node_modules/@testing-library/jest-dom": {
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
+            "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
+            "dev": true,
+            "dependencies": {
+                "@adobe/css-tools": "^4.3.2",
+                "@babel/runtime": "^7.9.2",
+                "aria-query": "^5.0.0",
+                "chalk": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "lodash": "^4.17.21",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            },
+            "peerDependencies": {
+                "@jest/globals": ">= 28",
+                "@types/bun": "latest",
+                "@types/jest": ">= 28",
+                "jest": ">= 28",
+                "vitest": ">= 0.32"
+            },
+            "peerDependenciesMeta": {
+                "@jest/globals": {
+                    "optional": true
+                },
+                "@types/bun": {
+                    "optional": true
+                },
+                "@types/jest": {
+                    "optional": true
+                },
+                "jest": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/test/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@storybook/test/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@storybook/test/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true
+        },
+        "node_modules/@storybook/test/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@storybook/test/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@storybook/theming": {
             "version": "8.1.11",
             "dev": true,
@@ -5263,12 +5368,12 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "6.4.5",
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.2.tgz",
+            "integrity": "sha512-P6GJD4yqc9jZLbe98j/EkyQDTPgqftohZF5FBkHY5BUERZmcf4HeO2k0XaefEg329ux2p21i1A1DmyQ1kKw2Jw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@adobe/css-tools": "^4.3.2",
-                "@babel/runtime": "^7.9.2",
+                "@adobe/css-tools": "^4.4.0",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
                 "css.escape": "^1.5.1",
@@ -5280,30 +5385,6 @@
                 "node": ">=14",
                 "npm": ">=6",
                 "yarn": ">=1"
-            },
-            "peerDependencies": {
-                "@jest/globals": ">= 28",
-                "@types/bun": "latest",
-                "@types/jest": ">= 28",
-                "jest": ">= 28",
-                "vitest": ">= 0.32"
-            },
-            "peerDependenciesMeta": {
-                "@jest/globals": {
-                    "optional": true
-                },
-                "@types/bun": {
-                    "optional": true
-                },
-                "@types/jest": {
-                    "optional": true
-                },
-                "jest": {
-                    "optional": true
-                },
-                "vitest": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -5354,6 +5435,33 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+            "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0",
+                "@types/react-dom": "^18.0.0",
+                "react": "^18.0.0",
+                "react-dom": "^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@testing-library/user-event": {
@@ -6620,6 +6728,128 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/mocker": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.3.tgz",
+            "integrity": "sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "2.1.3",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.11"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/spy": "2.1.3",
+                "msw": "^2.3.5",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true
+        },
+        "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
+            "integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
+            "dev": true,
+            "dependencies": {
+                "tinyspy": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/tinyspy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.3.tgz",
+            "integrity": "sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==",
+            "dev": true,
+            "dependencies": {
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.3.tgz",
+            "integrity": "sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/utils": "2.1.3",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
+            "integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.3",
+                "loupe": "^3.1.1",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/loupe": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+            "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+            "dev": true
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.3.tgz",
+            "integrity": "sha512-qWC2mWc7VAXmjAkEKxrScWHWFyCQx/cmiZtuGqMi+WwqQJ2iURsVY4ZfAK6dVo6K2smKRU6l3BPwqEBvhnpQGg==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.3",
+                "magic-string": "^0.30.11",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@vitest/spy": {
             "version": "1.6.0",
             "dev": true,
@@ -6895,6 +7125,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -7266,6 +7508,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "dev": true,
@@ -7625,6 +7873,15 @@
             "license": "MIT",
             "dependencies": {
                 "typewise-core": "^1.2"
+            }
+        },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/call-bind": {
@@ -7999,6 +8256,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "7.2.0",
             "license": "MIT",
@@ -8227,6 +8496,18 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/cssstyle": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+            "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+            "dev": true,
+            "dependencies": {
+                "rrweb-cssom": "^0.7.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/csstype": {
             "version": "3.1.3",
@@ -8606,6 +8887,53 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/tr46": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "^5.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",
             "dev": true,
@@ -8680,6 +9008,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "dev": true
         },
         "node_modules/deck.gl": {
             "version": "9.0.21",
@@ -8855,6 +9189,15 @@
             "peer": true,
             "dependencies": {
                 "robust-predicates": "^3.0.2"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/depd": {
@@ -9724,6 +10067,12 @@
                 "lodash": "^4.17.15"
             }
         },
+        "node_modules/eslint-plugin-vitest-globals": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vitest-globals/-/eslint-plugin-vitest-globals-1.5.0.tgz",
+            "integrity": "sha512-ZSsVOaOIig0oVLzRTyk8lUfBfqzWxr/J3/NFMfGGRIkGQPejJYmDH3gXmSJxAojts77uzAGB/UmVrwi2DC4LYA==",
+            "dev": true
+        },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
             "dev": true,
@@ -10415,6 +10764,20 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/form-data": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "dev": true,
@@ -10979,6 +11342,18 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/html-tags": {
             "version": "3.3.1",
             "dev": true,
@@ -11003,6 +11378,32 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -11030,7 +11431,6 @@
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -11517,6 +11917,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true
+        },
         "node_modules/is-regex": {
             "version": "1.1.4",
             "dev": true,
@@ -11885,6 +12291,80 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "25.0.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+            "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+            "dev": true,
+            "dependencies": {
+                "cssstyle": "^4.1.0",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.4.3",
+                "form-data": "^4.0.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.12",
+                "parse5": "^7.1.2",
+                "rrweb-cssom": "^0.7.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.0.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^2.11.2"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/tr46": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-url": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "^5.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/jsep": {
@@ -13083,6 +13563,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.13",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
+            "integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==",
+            "dev": true
+        },
         "node_modules/nypm": {
             "version": "0.3.9",
             "dev": true,
@@ -13614,6 +14100,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
+            "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
+            "dev": true,
+            "dependencies": {
+                "entities": "^4.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/parseurl": {
@@ -14754,6 +15252,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+            "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+            "dev": true
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "dev": true,
@@ -14835,6 +15339,18 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -15012,6 +15528,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
@@ -15221,6 +15743,12 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true
+        },
         "node_modules/statuses": {
             "version": "2.0.1",
             "dev": true,
@@ -15228,6 +15756,12 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+            "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+            "dev": true
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
@@ -15534,6 +16068,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "node_modules/tabbable": {
             "version": "6.2.0",
             "dev": true,
@@ -15750,10 +16290,40 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+            "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+            "dev": true
+        },
+        "node_modules/tinypool": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+            "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
         "node_modules/tinyqueue": {
             "version": "2.0.3",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/tinyrainbow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/tinyspy": {
             "version": "2.2.1",
@@ -15762,6 +16332,24 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/tldts": {
+            "version": "6.1.55",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.55.tgz",
+            "integrity": "sha512-HxQR/9roQ07Pwc8RyyrJMAxRz5/ssoF3qIPPUiIo3zUt6yMdmYZjM2OZIFMiZ3jHyz9jrGHEHuQZrUhoc1LkDw==",
+            "dev": true,
+            "dependencies": {
+                "tldts-core": "^6.1.55"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.55",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.55.tgz",
+            "integrity": "sha512-BL+BuKHHaOpntE5BGI6naXjULU6aRlgaYdfDHR3T/hdbNTWkWUZ9yuc11wGnwgpvRwlyUiIK+QohYK3olaVU6Q==",
+            "dev": true
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -15793,6 +16381,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+            "dev": true,
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/tr46": {
@@ -16387,6 +16987,27 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.3.tgz",
+            "integrity": "sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==",
+            "dev": true,
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.6",
+                "pathe": "^1.1.2",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/vite-plugin-dts": {
             "version": "4.2.4",
             "dev": true,
@@ -16467,6 +17088,178 @@
                 "@esbuild/win32-x64": "0.21.5"
             }
         },
+        "node_modules/vitest": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.3.tgz",
+            "integrity": "sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/expect": "2.1.3",
+                "@vitest/mocker": "2.1.3",
+                "@vitest/pretty-format": "^2.1.3",
+                "@vitest/runner": "2.1.3",
+                "@vitest/snapshot": "2.1.3",
+                "@vitest/spy": "2.1.3",
+                "@vitest/utils": "2.1.3",
+                "chai": "^5.1.1",
+                "debug": "^4.3.6",
+                "magic-string": "^0.30.11",
+                "pathe": "^1.1.2",
+                "std-env": "^3.7.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.0",
+                "tinypool": "^1.0.0",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0",
+                "vite-node": "2.1.3",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "2.1.3",
+                "@vitest/ui": "2.1.3",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/expect": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.3.tgz",
+            "integrity": "sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "2.1.3",
+                "@vitest/utils": "2.1.3",
+                "chai": "^5.1.1",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/spy": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
+            "integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
+            "dev": true,
+            "dependencies": {
+                "tinyspy": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/utils": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
+            "integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.3",
+                "loupe": "^3.1.1",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/chai": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+            "dev": true,
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 16"
+            }
+        },
+        "node_modules/vitest/node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/vitest/node_modules/loupe": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+            "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+            "dev": true
+        },
+        "node_modules/vitest/node_modules/pathval": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
+        "node_modules/vitest/node_modules/tinyspy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.0.8",
             "dev": true,
@@ -16480,6 +17273,18 @@
                 "@mapbox/point-geometry": "0.1.0",
                 "@mapbox/vector-tile": "^1.3.1",
                 "pbf": "^3.2.1"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/watch": {
@@ -16534,6 +17339,27 @@
             "version": "0.6.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "dev": true,
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -16631,6 +17457,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {
@@ -16775,6 +17617,21 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
         },
         "node_modules/xss": {
             "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
         "prepare": "husky install",
+        "test": "vitest",
         "watch": "vite build --watch"
     },
     "files": [
@@ -45,6 +46,8 @@
         "@storybook/react": "^8.0.10",
         "@storybook/react-vite": "^8.0.10",
         "@storybook/test": "^8.0.10",
+        "@testing-library/jest-dom": "^6.6.2",
+        "@testing-library/react": "^16.0.1",
         "@types/css-modules": "^1.0.5",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
@@ -61,7 +64,9 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.6",
         "eslint-plugin-storybook": "^0.8.0",
+        "eslint-plugin-vitest-globals": "^1.5.0",
         "husky": "^8.0.0",
+        "jsdom": "^25.0.1",
         "lint-staged": "^15.2.2",
         "maplibre-gl": "^4.3.2",
         "prettier": "^3.2.5",
@@ -70,6 +75,7 @@
         "typescript": "^5.6.3",
         "vite": "^5.2.0",
         "vite-plugin-dts": "^4.2.4",
+        "vitest": "^2.1.3",
         "watch": "^1.0.2"
     }
 }

--- a/src/components/core/Swatch.test.tsx
+++ b/src/components/core/Swatch.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { Swatch } from "./Swatch";
+
+describe("Swatch", () => {
+    it("renders with correct color", () => {
+        render(<Swatch color="#FF0000" />);
+        // getByTestId isn't the best approach to selecting elements in tests
+        // The preference would be to use a more semantic approach, using getByRole() or another method
+        const swatchElement = screen.getByTestId("swatch");
+        expect(swatchElement).toHaveStyle("background-color: #FF0000");
+    });
+
+    it("renders with label when provided", () => {
+        render(<Swatch color="#FF0000" label="Red" />);
+        expect(screen.getByText("Red")).toBeInTheDocument();
+    });
+
+    it("renders without label when not provided", () => {
+        render(<Swatch color="#FF0000" />);
+        const labelElement = screen.queryByTestId("swatch-label");
+        expect(labelElement).toBeEmptyDOMElement();
+    });
+
+    it("renders with value and units when provided", () => {
+        render(<Swatch color="#FF0000" value={50} units="%" />);
+        expect(screen.getByText("50%")).toBeInTheDocument();
+    });
+
+    it("renders without value and units when not provided", () => {
+        render(<Swatch color="#FF0000" />);
+        const valueElement = screen.queryByTestId("swatch-value");
+        expect(valueElement).toBeEmptyDOMElement();
+    });
+
+    it("renders with all props provided", () => {
+        render(<Swatch color="#00FF00" label="Green" value={75} units="px" />);
+        expect(screen.getByTestId("swatch")).toHaveStyle(
+            "background-color: #00FF00",
+        );
+        expect(screen.getByText("Green")).toBeInTheDocument();
+        expect(screen.getByText("75px")).toBeInTheDocument();
+    });
+});

--- a/src/components/core/Swatch.tsx
+++ b/src/components/core/Swatch.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./Swatch.module.css";
 
 interface SwatchProps {
@@ -8,18 +7,20 @@ interface SwatchProps {
     units?: string;
 }
 
-export const Swatch: React.FC<SwatchProps> = ({
-    color,
-    label = "",
-    value,
-    units = "",
-}) => (
+export const Swatch = ({ color, label = "", value, units = "" }: SwatchProps) => (
     <div className={styles.swatchContainer}>
-        <div className={styles.swatch} style={{ backgroundColor: color }} />
-        <div className={styles.swatchLabel}>{label}</div>
-        <div className={styles.swatchValue}>
-            {value}
-            {units}
+        <div
+            // data-testid isn't the best approach to selecting elements in tests
+            // The preference would be to use a more semantic approach, using getByRole() or another method
+            data-testid="swatch"
+            className={styles.swatch}
+            style={{ backgroundColor: color }}
+        />
+        <div data-testid="swatch-label" className={styles.swatchLabel}>
+            {label}
+        </div>
+        <div data-testid="swatch-value" className={styles.swatchValue}>
+            {value !== undefined && `${value}${units}`}
         </div>
     </div>
 );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "*.module.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,18 @@
       "isolatedModules": true,
       "noEmit": true,
       "jsx": "react-jsx",
+      "allowJs": true,
+      "esModuleInterop": true,
 
       /* Linting */
       "strict": true,
       "noUnusedLocals": true,
       "noUnusedParameters": true,
-      "noFallthroughCasesInSwitch": true
+      "noFallthroughCasesInSwitch": true,
+
+      /* Testing types */
+      "types": ["vitest/globals", "@testing-library/jest-dom"]
+
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 import * as packageJson from "./package.json";
 
@@ -9,6 +9,11 @@ export default defineConfig({
     plugins: [
         react(),
     ],
+    test: {
+        globals: true,
+        environment: 'jsdom',
+        setupFiles: ['./src/setupTests.ts'],
+    },
     build: {
         lib: {
             entry: resolve("src", "components/index.ts"),


### PR DESCRIPTION


# Description

Add vitest, testing-library and jsdom packages.
Update configuration files.
Add setupTests.ts.
Add example test for Swatch component.
Add error handling to lint-staged config.
Worked out some outstanding TS issues.

Related issue: #27

## Type of change

*Delete options that are not relevant.*

- [x] New feature (non-breaking change which adds functionality)

# Instructions

Run `npm run test`