### PR TITLE
test: Add tests for datepicker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,19 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
+        - uses: actions/checkout@v4
+        
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: '22.11.0'
+            
+        - name: Install dependencies
+          run: npm ci
+            
+        - name: Run Vitest tests
+          run: npm run test -- --run --coverage=false
+          
         - id: build-publish
           uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
           with:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# If perormance becomes an issue, consider using Vitest's --changed flag to run only the tests affected by the changes
+npm run test -- --run --coverage=false || exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@storybook/test": "^8.0.10",
                 "@testing-library/jest-dom": "^6.6.2",
                 "@testing-library/react": "^16.0.1",
+                "@testing-library/user-event": "^14.5.2",
                 "@types/css-modules": "^1.0.5",
                 "@types/react": "^18.3.11",
                 "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "@storybook/test": "^8.0.10",
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/css-modules": "^1.0.5",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",

--- a/src/components/core/DatePicker.module.css
+++ b/src/components/core/DatePicker.module.css
@@ -3,8 +3,10 @@
         so we can override rules here without rewriting all of them
     */
     composes: react-aria-DatePicker from global;
-
     /* See src/components/core/DatePicker.css for ideas on customizing this component */
+
+    display: flex;
+    flex-direction: column;
 }
 
 .dateInput {

--- a/src/components/core/DatePicker.test.tsx
+++ b/src/components/core/DatePicker.test.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import { vi } from "vitest";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { parseDate } from "@internationalized/date";
+
+import { DateValue } from "react-aria";
+import { DatePicker } from "./DatePicker";
+
+describe("DatePicker", () => {
+    // Helper to create a test date value
+    const testDate = parseDate("2024-01-15");
+
+    // Common props used across tests
+    const defaultProps = {
+        value: testDate,
+        onChange: vi.fn(),
+        label: "Test Date",
+    };
+
+    it("renders with a visible label", () => {
+        render(<DatePicker {...defaultProps} />);
+
+        // Check for label and date input
+        expect(
+            screen.getByText("Test Date", {
+                selector: ".react-aria-Label",
+            }),
+        ).toBeInTheDocument();
+
+        expect(screen.getByRole("presentation")).toBeInTheDocument();
+    });
+
+    it("renders with aria-label when no visible label is provided", () => {
+        render(
+            <DatePicker
+                value={testDate}
+                onChange={defaultProps.onChange}
+                aria-label="Choose date"
+            />,
+        );
+
+        // Verify the input is accessible
+        expect(
+            screen.getByRole("group", { name: "Choose date" }),
+        ).toBeInTheDocument();
+    });
+
+    it("displays helper text when provided", () => {
+        const helperText = "Select a valid date";
+        render(<DatePicker {...defaultProps} helperText={helperText} />);
+
+        expect(screen.getByText(helperText)).toBeInTheDocument();
+    });
+
+    it("displays error message when date is set above max value", async () => {
+        const user = userEvent.setup();
+        const errorMessage = "Date is required";
+        const TestWrapper = () => {
+            const [date, setDate] = useState<DateValue | null>(testDate);
+
+            return (
+                <DatePicker
+                    {...defaultProps}
+                    value={date}
+                    onChange={setDate}
+                    errorMessage={errorMessage}
+                    maxValue={parseDate("2024-11-26")}
+                />
+            );
+        };
+
+        render(<TestWrapper />);
+
+        // Get the year spinbutton
+        const yearSpinbutton = screen.getByRole("spinbutton", {
+            name: /year/i,
+        });
+
+        // Type a new year
+        await user.type(yearSpinbutton, "2025");
+        // Tab away to trigger validation
+        await user.tab();
+
+        expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    it("opens calendar popover when calendar button is clicked", async () => {
+        const user = userEvent.setup();
+        render(<DatePicker {...defaultProps} />);
+
+        // Click the calendar button
+        const calendarButton = screen.getByRole("button", {
+            name: /open calendar/i,
+        });
+        await user.click(calendarButton);
+
+        // Verify calendar is displayed
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(screen.getByRole("grid")).toBeInTheDocument();
+    });
+
+    it("calls onChange when a date is selected", async () => {
+        const user = userEvent.setup();
+        render(<DatePicker {...defaultProps} />);
+
+        // Open calendar
+        const calendarButton = screen.getByRole("button", {
+            name: /open calendar/i,
+        });
+        await user.click(calendarButton);
+
+        // Click a date (assuming it exists in the current month view)
+        const dateButton = screen.getByRole("button", { name: /15/i });
+        await user.click(dateButton);
+
+        // Verify onChange was called
+        await waitFor(() => {
+            expect(defaultProps.onChange).toHaveBeenCalled();
+        });
+    });
+
+    it("renders with ReactNode label", () => {
+        render(
+            <DatePicker
+                {...defaultProps}
+                label={<div data-testid="custom-label">Custom Label</div>}
+            />,
+        );
+
+        expect(screen.getByTestId("custom-label")).toBeInTheDocument();
+    });
+
+    it("navigates between months using previous/next buttons", async () => {
+        const user = userEvent.setup();
+        render(<DatePicker {...defaultProps} />);
+
+        // Open calendar
+        const calendarButton = screen.getByRole("button", {
+            name: /open calendar/i,
+        });
+        await user.click(calendarButton);
+
+        // Get navigation buttons
+        const header = screen.getByRole("banner");
+        const prevButton = within(header).getByRole("button", {
+            name: /previous/i,
+        });
+        const nextButton = within(header).getByRole("button", {
+            name: /next/i,
+        });
+
+        // Navigate and verify month changes
+        await user.click(nextButton);
+        await user.click(prevButton);
+
+        // Buttons should still be present after navigation
+        expect(prevButton).toBeInTheDocument();
+        expect(nextButton).toBeInTheDocument();
+    });
+});

--- a/src/components/core/DatePicker.tsx
+++ b/src/components/core/DatePicker.tsx
@@ -1,5 +1,9 @@
 import { useState, JSX, ReactNode } from "react";
-import type { ValidationResult } from "react-aria-components";
+import type {
+    ValidationResult,
+    DatePickerProps as ReactAriaDatePickerProps,
+    DateValue,
+} from "react-aria-components";
 import {
     Button,
     Calendar,
@@ -21,11 +25,11 @@ import { useHover } from "react-aria";
 import { faCalendar } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 // import the module, not the default react-aria css file (src/components/core/DatePicker.css)
-import { DateValue } from "@internationalized/date";
 import styles from "./DatePicker.module.css";
 
 // Base interface with explicit types and descriptions
-interface BaseDatePickerProps {
+interface BaseDatePickerProps
+    extends Omit<ReactAriaDatePickerProps<DateValue>, "children"> {
     /** The currently selected date */
     value: DateValue | null;
     /** Callback fired when the date changes */
@@ -78,6 +82,8 @@ export type DatePickerProps =
  *        DateValue type from '@internationalized/date'.
  * @param {Function} props.onChange - Callback fired when the date changes.
  *        Receives the new DateValue or null as its argument.
+ * @param {ReactAriaDatePickerProps} props - Additional props from react-aria-components DatePicker.
+ *        See react-aria-components documentation for all available props.
  * @returns {React.ReactElement} The rendered date picker component.
  */
 export const DatePicker = ({
@@ -88,6 +94,7 @@ export const DatePicker = ({
     onChange,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
+    ...props
 }: DatePickerProps): JSX.Element => {
     const [isButtonHovered, setIsButtonHovered] = useState(false);
     const { hoverProps, isHovered } = useHover({});
@@ -99,6 +106,7 @@ export const DatePicker = ({
             onChange={onChange}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledBy}
+            {...props}
         >
             {label && <Label>{label}</Label>}
             <Group>

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -1,7 +1,8 @@
-import { ReactNode, useState } from "react";
+import { useState } from "react";
 import { parseDate } from "@internationalized/date";
 import { DateValue } from "react-aria-components";
 import { DatePicker } from "../components";
+import { DatePickerProps } from "../components/core/DatePicker";
 
 export default {
     title: "Core/DatePicker",
@@ -16,19 +17,39 @@ export default {
             },
         },
     },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        helperText: {
+            control: "text",
+        },
+        errorMessage: {
+            control: "text",
+        },
+        "aria-label": {
+            control: "text",
+        },
+        "aria-labelledby": {
+            control: "text",
+        },
+    },
 };
 
-interface StoryArgs {
-    label?: string | ReactNode;
-    helperText?: string;
-    errorMessage?: string;
-}
+type StoryArgs = DatePickerProps;
 
 export const BasicDatePicker = {
     args: {
         label: "This is the label",
         helperText: "This is the helper text",
         errorMessage: "This is the error message",
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "A basic implementation of the DatePicker component showing all standard props: label, helper text, and error message. This represents the most common usage of the component.",
+            },
+        },
     },
     render: (args: StoryArgs) => {
         const [date, setDate] = useState<DateValue | null>(
@@ -50,12 +71,19 @@ export const BasicDatePicker = {
 export const DatePickerWithReactNodeLabel = {
     args: {
         label: (
-            <div style={{ color: "red" }}>
+            <div style={{ color: "blue" }}>
                 {`This is a label, but it's also a ReactNode (i.e. an element)`}
             </div>
         ),
         helperText: "This is the helper text",
         errorMessage: "This is the error message",
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Demonstrates how to use a ReactNode as a label instead of a simple string. This allows for rich formatting and custom styling of the label content.",
+            },
+        },
     },
     render: (args: StoryArgs) => {
         const [date, setDate] = useState<DateValue | null>(
@@ -77,6 +105,14 @@ export const DatePickerWithReactNodeLabel = {
 export const DatePickerNoLabelOrHelperText = {
     args: {
         errorMessage: "This is the error message",
+        "aria-label": "This is an accessible label",
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Shows a minimal DatePicker configuration without visible label or helper text, but maintaining accessibility through aria-label. Useful for space-constrained UIs while ensuring accessibility standards are met.",
+            },
+        },
     },
     render: (args: StoryArgs) => {
         const [date, setDate] = useState<DateValue | null>(
@@ -88,7 +124,41 @@ export const DatePickerNoLabelOrHelperText = {
                 value={date}
                 onChange={setDate}
                 errorMessage={args.errorMessage || ""}
-                aria-label="This is an accessible label"
+                aria-label={args["aria-label"] || ""}
+            />
+        );
+    },
+};
+
+export const DatePickerWithMaxDate = {
+    args: {
+        label: "This is the label",
+        errorMessage: "This is the error message",
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Illustrates how to set a maximum selectable date (maxValue) for the DatePicker. In this example, the maximum date is set to yesterday, preventing users from selecting future dates. Setting the date to a future date manually will display the error message. Note that all props available in react-aria components are supported (see https://react-spectrum.adobe.com/react-aria/DatePicker.html#props for more information).",
+            },
+        },
+    },
+    render: (args: StoryArgs) => {
+        const [date, setDate] = useState<DateValue | null>(
+            parseDate(new Date().toISOString().slice(0, 10)),
+        );
+
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() - 1);
+
+        const maxDate = parseDate(tomorrow.toISOString().slice(0, 10));
+
+        return (
+            <DatePicker
+                label={args.label || ""}
+                value={date}
+                onChange={setDate}
+                errorMessage={args.errorMessage || ""}
+                maxValue={maxDate}
             />
         );
     },


### PR DESCRIPTION
# Description

- Add tests for datepicker.
- Update DatePicker to accept react-aria DatePicker props.
- Update datepicker display style to flex.
- Add steps to deploy process to run tests.
- Add pre-push step to run tests.
- Update stories to demonstrate use of props and error text.

Related issue: #44

# Instructions

Run `npm run test`

# How Has This Been Tested?

Tests can be found in `src/components/core/DatePicker.test.tsx`. They attempt to cover the majority of the DatePicker functionality while remaining succinct.